### PR TITLE
Fix UnsupportedOperationException

### DIFF
--- a/src/main/java/net/raphimc/mcauth/step/msa/MsaCodeStep.java
+++ b/src/main/java/net/raphimc/mcauth/step/msa/MsaCodeStep.java
@@ -44,7 +44,7 @@ public class MsaCodeStep<I extends AbstractStep.StepResult<?>> extends AbstractS
 
     @Override
     public MsaCode fromJson(JsonObject json) throws Exception {
-        return new MsaCode(json.get("code").getAsString(), json.get("clientId").getAsString(), json.get("scope").getAsString(), json.get("clientSecret") != null ? json.get("clientSecret").getAsString() : null, null);
+        return new MsaCode(json.get("code").getAsString(), json.get("clientId").getAsString(), json.get("scope").getAsString(), json.get("clientSecret") != null && !json.get("clientSecret").isJsonNull() ? json.get("clientSecret").getAsString() : null, null);
     }
 
     public static final class MsaCode implements AbstractStep.StepResult<AbstractStep.StepResult<?>> {


### PR DESCRIPTION
```
java.lang.UnsupportedOperationException: JsonNull
        at com.google.gson.JsonElement.getAsString(JsonElement.java:187) ~[ProxyPass.jar:?]
        at net.raphimc.mcauth.step.msa.MsaCodeStep.fromJson(MsaCodeStep.java:47) ~[ProxyPass.jar:?]
        at net.raphimc.mcauth.step.msa.MsaCodeStep.fromJson(MsaCodeStep.java:26) ~[ProxyPass.jar:?]
        at net.raphimc.mcauth.step.msa.StepMsaToken.fromJson(StepMsaToken.java:60) ~[ProxyPass.jar:?]
        at net.raphimc.mcauth.step.msa.StepMsaToken.fromJson(StepMsaToken.java:37) ~[ProxyPass.jar:?]
        at net.raphimc.mcauth.step.xbl.session.StepInitialXblSession.fromJson(StepInitialXblSession.java:45) ~[ProxyPass.jar:?]
        at net.raphimc.mcauth.step.xbl.session.StepInitialXblSession.fromJson(StepInitialXblSession.java:29) ~[ProxyPass.jar:?]
        at net.raphimc.mcauth.step.xbl.StepXblSisuAuthentication.fromJson(StepXblSisuAuthentication.java:102) ~[ProxyPass.jar:?]
        at net.raphimc.mcauth.step.xbl.StepXblSisuAuthentication.fromJson(StepXblSisuAuthentication.java:36) ~[ProxyPass.jar:?]
        at net.raphimc.mcauth.step.bedrock.StepMCChain.fromJson(StepMCChain.java:125) ~[ProxyPass.jar:?]
        at net.raphimc.mcauth.step.bedrock.StepMCChain.fromJson(StepMCChain.java:48) ~[ProxyPass.jar:?]
        at org.cloudburstmc.proxypass.network.bedrock.session.Account.<init>(Account.java:26) ~[ProxyPass.jar:?]
        at org.cloudburstmc.proxypass.ProxyPass.getAuthenticatedAccount(ProxyPass.java:357) ~[ProxyPass.jar:?]
        at org.cloudburstmc.proxypass.ProxyPass.boot(ProxyPass.java:164) ~[ProxyPass.jar:?]
        at org.cloudburstmc.proxypass.ProxyPass.main(ProxyPass.java:126) ~[ProxyPass.jar:?]
```
Occurs when `clientSecret` is explicitly null instead of omitted.