### PR TITLE
Added a way to access the username (clientId) in the MCToken

### DIFF
--- a/src/main/java/net/raphimc/minecraftauth/step/java/StepMCToken.java
+++ b/src/main/java/net/raphimc/minecraftauth/step/java/StepMCToken.java
@@ -52,6 +52,7 @@ public class StepMCToken extends AbstractStep<StepXblXstsToken.XblXsts<?>, StepM
         final JsonObject obj = httpClient.execute(postRequest, new MinecraftResponseHandler());
 
         final MCToken mcToken = new MCToken(
+                obj.get("username").getAsString(),
                 obj.get("access_token").getAsString(),
                 obj.get("token_type").getAsString(),
                 System.currentTimeMillis() + obj.get("expires_in").getAsLong() * 1000,
@@ -65,6 +66,7 @@ public class StepMCToken extends AbstractStep<StepXblXstsToken.XblXsts<?>, StepM
     public MCToken fromJson(final JsonObject json) {
         final StepXblXstsToken.XblXsts<?> xblXsts = this.prevStep != null ? this.prevStep.fromJson(json.getAsJsonObject(this.prevStep.name)) : null;
         return new MCToken(
+                json.get("username").getAsString(),
                 json.get("accessToken").getAsString(),
                 json.get("tokenType").getAsString(),
                 json.get("expireTimeMs").getAsLong(),
@@ -75,6 +77,7 @@ public class StepMCToken extends AbstractStep<StepXblXstsToken.XblXsts<?>, StepM
     @Override
     public JsonObject toJson(final MCToken mcToken) {
         final JsonObject json = new JsonObject();
+        json.addProperty("username", mcToken.username);
         json.addProperty("accessToken", mcToken.accessToken);
         json.addProperty("tokenType", mcToken.tokenType);
         json.addProperty("expireTimeMs", mcToken.expireTimeMs);
@@ -86,6 +89,7 @@ public class StepMCToken extends AbstractStep<StepXblXstsToken.XblXsts<?>, StepM
     @EqualsAndHashCode(callSuper = false)
     public static class MCToken extends AbstractStep.StepResult<StepXblXstsToken.XblXsts<?>> {
 
+        String username;
         String accessToken;
         String tokenType;
         long expireTimeMs;


### PR DESCRIPTION
~~I would like to access `clientId` and `xuid` from a `StepFullJavaSession.FullJavaSession`.~~

~~This has been discussed last year in your discord, but the conclusion was that they are not needed since they are optional in Java Edition. But the game can still make use of them, so I would rather have them than not.~~

~~The `xuid` can already be accessed, it should be `XblXsts.getUserHash()`.~~

~~But the `clientId` can not, from my understanding it should be the `username` field in the response from https://api.minecraftservices.com/launcher/login encoded with base64. This PR provides that field. Note that `username` is not a name, but rather a UUID.~~

~~This might affect backwards compatibility with jsons that do not yet have this field, `json.get("username").getAsString()` might cause a NullPointer. Should we take that into account and make the field Nullable?~~

~~If you do not want this, you can close this PR. I can probably also do this by forking or sub-classing some of the builders, but that would be a bit annoying.~~

Just about everything in this is wrong 😅 
