### PR TITLE
Added close callback to JavaFxWebview

### DIFF
--- a/src/main/java/net/raphimc/minecraftauth/step/msa/StepJfxWebViewMsaCode.java
+++ b/src/main/java/net/raphimc/minecraftauth/step/msa/StepJfxWebViewMsaCode.java
@@ -21,6 +21,7 @@ import javafx.application.Platform;
 import javafx.embed.swing.JFXPanel;
 import javafx.scene.Scene;
 import javafx.scene.web.WebView;
+import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.SneakyThrows;
 import lombok.Value;
@@ -43,6 +44,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 public class StepJfxWebViewMsaCode extends MsaCodeStep<StepJfxWebViewMsaCode.JavaFxWebView> {
 
@@ -112,28 +114,37 @@ public class StepJfxWebViewMsaCode extends MsaCodeStep<StepJfxWebViewMsaCode.Jav
 
         try {
             final MsaCode msaCode = msaCodeFuture.get(this.timeout, TimeUnit.MILLISECONDS);
-            window.dispose();
             logger.info(this, "Got MSA Code");
             return msaCode;
         } catch (TimeoutException e) {
-            window.dispose();
             throw new TimeoutException("MSA login timed out");
         } catch (ExecutionException e) {
-            window.dispose();
             if (e.getCause() != null) {
                 throw e.getCause();
             } else {
                 throw e;
             }
+        } finally {
+            if (javaFxWebViewCallback == null) {
+                window.dispose();
+            } else {
+                javaFxWebViewCallback.closeCallback.accept(window);
+            }
         }
     }
 
     @Value
+    @AllArgsConstructor
     @EqualsAndHashCode(callSuper = false)
     public static class JavaFxWebView extends AbstractStep.InitialInput {
 
-        BiConsumer<JFrame, WebView> openCallback = (window, webView) -> window.setVisible(true);
+        BiConsumer<JFrame, WebView> openCallback;
+        Consumer<JFrame> closeCallback;
 
+        public JavaFxWebView() {
+            this.openCallback = (window, webView) -> window.setVisible(true);
+            this.closeCallback = JFrame::dispose;
+        }
     }
 
     public static class UserClosedWindowException extends Exception {

--- a/src/main/java/net/raphimc/minecraftauth/step/msa/StepJfxWebViewMsaCode.java
+++ b/src/main/java/net/raphimc/minecraftauth/step/msa/StepJfxWebViewMsaCode.java
@@ -145,6 +145,7 @@ public class StepJfxWebViewMsaCode extends MsaCodeStep<StepJfxWebViewMsaCode.Jav
             this.openCallback = (window, webView) -> window.setVisible(true);
             this.closeCallback = JFrame::dispose;
         }
+
     }
 
     public static class UserClosedWindowException extends Exception {


### PR DESCRIPTION
Issue was that a login with webview only worked once, then JFrames never opened again.

If you dispose the last JFrame JavaFX will shutdown for good, then you cannot open anymore JFrames with JavaFX. You can prevent that by calling Platform.setImplicitExit(false); but then the JavaFX Thread will keep running, even after your main thread is already done, so if you want your application to shutdown you need to shutdown JavaFX explicitly or call System.exit. I think the best way to fix this would be to let applications handle how they want to dispose the window themselves.