### PR TITLE
Added JavaFxWebView constructor that does not expose JavaFX

### DIFF
--- a/src/main/java/net/raphimc/minecraftauth/step/msa/StepJfxWebViewMsaCode.java
+++ b/src/main/java/net/raphimc/minecraftauth/step/msa/StepJfxWebViewMsaCode.java
@@ -146,6 +146,11 @@ public class StepJfxWebViewMsaCode extends MsaCodeStep<StepJfxWebViewMsaCode.Jav
             this.closeCallback = JFrame::dispose;
         }
 
+        public JavaFxWebView(final Consumer<JFrame> openCallback, final Consumer<JFrame> closeCallback) {
+            this.openCallback = (window, webview) -> openCallback.accept(window);
+            this.closeCallback = closeCallback;
+        }
+
     }
 
     public static class UserClosedWindowException extends Exception {


### PR DESCRIPTION
Without this PR projects can not instantiate a JavaFxWebView and specify the callbacks without adding javafx as a dependency or stubbing the webview class.